### PR TITLE
Export XY-Grid components in src/index.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,4 +20,5 @@ export { Switch, SwitchInput, SwitchPaddle, SwitchActive, SwitchInactive } from 
 export { Thumbnail, ThumbnailLink } from './components/thumbnail';
 export { Tabs, TabItem, TabsContent, TabPanel } from './components/tabs';
 export { TopBar, TopBarTitle, TopBarLeft, TopBarRight } from './components/top-bar';
+export { GridContainer, Grid, Cell } from './components/xy-grid';
 export { Breakpoints, Colors, Sizes, Alignments, FloatTypes, InputTypes, GutterTypes, ExtendedBreakpoints, SpaceControls } from './enums';


### PR DESCRIPTION
This should fix #48. In my local copy (inside node_modules) I modified both `lib/index.js` & `src/index.js` and it fixed the issue referenced in #48. However I only see `src/index.js` in the repo, so I guess the other is generated later?

Fixes #48.

Changes proposed in this pull request:
 * Export XY-Grid components in src/index.js
