### PR TITLE
Add generalClassNames to XY-Grid <Cell>

### DIFF
--- a/src/components/xy-grid.js
+++ b/src/components/xy-grid.js
@@ -90,6 +90,7 @@ export const Cell = (props) => {
     isDefined(props.offsetOnSmall) ? `small-offset-${props.offsetOnSmall}` : null,
     isDefined(props.offsetOnMedium) ? `medium-offset-${props.offsetOnMedium}` : null,
     isDefined(props.offsetOnLarge) ? `large-offset-${props.offsetOnLarge}` : null,
+    generalClassNames(props)
   );
 
   const passProps = removeProps(props, objectKeys(Cell.propTypes));


### PR DESCRIPTION
I don't know whether this was left off intentionally, but it would be nice to be able to add props such as `isHidden` to `<Cell>` components.

Changes proposed in this pull request:
 * Add `generalClassNames` to XY-Grid's `<Cell>`
