### PR TITLE
GridContainer full / fluid generates render warning from React (#55)

### DIFF
--- a/src/components/xy-grid.js
+++ b/src/components/xy-grid.js
@@ -20,7 +20,7 @@ export const GridContainer = (props) => {
     generalClassNames(props)
   );
 
-  const passProps = removeProps(props, objectKeys(Grid.propTypes));
+  const passProps = removeProps(props, objectKeys(GridContainer.propTypes));
 
   return <div {...passProps} className={className}/>;
 };

--- a/test/components/xy-grid-spec.js
+++ b/test/components/xy-grid-spec.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import { render } from 'enzyme';
+import { render, shallow } from 'enzyme';
 import { expect } from 'chai';
-import { GutterTypes, ExtendedBreakpoints } from '../../src/enums'
+import { GutterTypes, ExtendedBreakpoints } from '../../src/enums';
 import { GridContainer, Grid, Cell } from '../../src/components/xy-grid';
 
 describe('GridContainer component', () => {
@@ -27,15 +27,16 @@ describe('GridContainer component', () => {
   });
 
   it('sets fluid', () => {
-    const component = render(<GridContainer fluid/>);
+    const component = shallow(<GridContainer fluid/>);
     expect(component).to.have.className('fluid');
+    expect(component).to.not.have.prop('fluid');
   });
 
   it('sets full', () => {
-    const component = render(<GridContainer full/>);
+    const component = shallow(<GridContainer full/>);
     expect(component).to.have.className('full');
+    expect(component).to.not.have.prop('full');
   });
-
 });
 
 describe('Grid component', () => {


### PR DESCRIPTION
(Please read the [guidelines](.github/CONTRIBUTING.md) before creating PRs.)

Fixes #.
GridContainer removes GridContainer.propTypes rather than Grid.propTypes.

Changes proposed in this pull request:
 * Unit tests check for removal of `fluid` and `full` props - note change to use `shallow()` rather than `render()` to be able to test props properly.
