### PR TITLE
Update Code Climate badges

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -205,8 +205,6 @@
     "react/jsx-sort-props": 0,
     "react/jsx-uses-react": 2,
     "react/jsx-uses-vars": 1,
-    "react/no-did-mount-set-state": [1, "allow-in-func"],
-    "react/no-did-update-set-state": [1, "allow-in-func"],
     "react/no-multi-comp": 0,
     "react/no-unknown-property": 0,
     "react/prop-types": 0,

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ after_script:
 
 addons:
     code_climate:
-        repo_token: 9eac8d2b468e15ffa2109c1984945db4230ab94232c64064a9a658b17be43c14
+        repo_token: 2d489d69b636c6f2f55bcbd103df3ced18bec35f0b57de1a4cdb2102094be833

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # React + Foundation
 
 [![Build Status](https://travis-ci.org/digiaonline/react-foundation.svg?branch=master)](https://travis-ci.org/digiaonline/react-foundation)
-[![Test Coverage](https://codeclimate.com/github/nordsoftware/react-foundation/badges/coverage.svg)](https://codeclimate.com/github/nordsoftware/react-foundation/coverage)
-[![Code Climate](https://codeclimate.com/github/nordsoftware/react-foundation/badges/gpa.svg)](https://codeclimate.com/github/nordsoftware/react-foundation)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/ea90da79f63c9d5dab1a/test_coverage)](https://codeclimate.com/github/digiaonline/react-foundation/test_coverage)
+[![Maintainability](https://api.codeclimate.com/v1/badges/ea90da79f63c9d5dab1a/maintainability)](https://codeclimate.com/github/digiaonline/react-foundation/maintainability)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/digiaonline/react-foundation/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/digiaonline/react-foundation/?branch=master)
 [![StyleCI](https://styleci.io/repos/53612920/shield?style=flat)](https://styleci.io/repos/53612920)
 [![npm version](https://img.shields.io/npm/v/react-foundation.svg)](https://www.npmjs.com/package/react-foundation)


### PR DESCRIPTION
I needed to add digiaonline/react-foundation as a new repo to check.

https://codeclimate.com/github/nordsoftware/react-foundation/
->
https://codeclimate.com/github/digiaonline/react-foundation/

Part of #65.

Badges aren't generating yet due to eslint errors:

```
/usr/src/app/lib/validate_config.js:17
        throw e;
        ^

Error: /code/.eslintrc:
	Configuration for rule "react/no-did-mount-set-state" is invalid:
	Value "allow-in-func" must be an enum value.

    at validateRuleOptions (/usr/local/node_modules/eslint/lib/config/config-validator.js:109:15)
    at Object.keys.forEach.id (/usr/local/node_modules/eslint/lib/config/config-validator.js:156:13)
    at Array.forEach (native)
    at Object.validate (/usr/local/node_modules/eslint/lib/config/config-validator.js:155:35)
    at Object.load (/usr/local/node_modules/eslint/lib/config/config-file.js:559:19)
    at loadConfig (/usr/local/node_modules/eslint/lib/config.js:63:33)
    at getLocalConfig (/usr/local/node_modules/eslint/lib/config.js:130:29)
    at Config.getConfig (/usr/local/node_modules/eslint/lib/config.js:260:26)
    at Config.getConfig (/usr/src/app/lib/eslint-patch.js:45:46)
    at CLIEngine.getConfigForFile (/usr/local/node_modules/eslint/lib/cli-engine.js:776:29)
```

https://codeclimate.com/github/digiaonline/react-foundation/builds/3

Any ideas?