### PR TITLE
include isClear to list of props for buttons

### DIFF
--- a/src/components/button.js
+++ b/src/components/button.js
@@ -14,6 +14,7 @@ const ButtonPropTypes = {
   color: PropTypes.oneOf(objectValues(ButtonColors)),
   size: PropTypes.oneOf(objectValues(ButtonSizes)),
   isHollow: PropTypes.bool,
+  isClear: PropTypes.bool,
   isExpanded: PropTypes.bool,
   isDisabled: PropTypes.bool,
   isDropdown: PropTypes.bool
@@ -63,6 +64,7 @@ function createButtonClassName(props) {
     props.color,
     {
       'hollow': props.isHollow,
+      'clear': props.isClear,
       'expanded': props.isExpanded,
       'disabled': props.isDisabled,
       'dropdown': props.isDropdown,

--- a/test/components/button-spec.js
+++ b/test/components/button-spec.js
@@ -46,6 +46,12 @@ describe('Button component', () => {
     expect(component).to.not.have.attr('isHollow');
   });
 
+  it('sets clear', () => {
+    const component = render(<Button isClear/>);
+    expect(component).to.have.className('clear');
+    expect(component).to.not.have.attr('isClear');
+  });
+
   it('sets expanded', () => {
     const component = render(<Button isExpanded/>);
     expect(component).to.have.className('expanded');


### PR DESCRIPTION
Changes proposed in this pull request:
 * Pass `isClear` as props to buttons rather than passing `clear` to the className to use the `clear` class. See [here](https://foundation.zurb.com/sites/docs/button.html#clear-style) for reference.


