### PR TITLE
Test on newest LTS Node.js version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@ language: node_js
 sudo: false
 
 node_js:
-  - "lts/boron"  # 6.x
-  - "lts/carbon" # 8.x
+  - "lts/boron"   # 6.x
+  - "lts/carbon"  # 8.x
+  - "lts/dubnium" # 10.x
   - "stable"
 
 script:


### PR DESCRIPTION
Changes proposed in this pull request:
 * Add Node.js 10.x to Travis CI, the newest LTS release
 * https://github.com/nodejs/Release
 * (`stable` is currently pointing to 11.x)

6.x Boron is EOL in April 2019, we can consider removing that soon (or now?).


---

![image](https://user-images.githubusercontent.com/1324225/53410975-05829180-39ce-11e9-8f3a-4b8b112f0979.png)





