### PR TITLE
Update to supported node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: node_js
 
 node_js:
-  - "lts/boron"   # 6.x
-  - "lts/carbon"  # 8.x
-  - "lts/dubnium" # 10.x
-  - "stable"
+  - "node"  # latest stable release
+  - "lts/*" # latest LTS release
 
 script:
   - npm run lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: node_js
 
-# Use container-based infrastructure
-sudo: false
-
 node_js:
   - "lts/boron"   # 6.x
   - "lts/carbon"  # 8.x


### PR DESCRIPTION
Changes proposed in this pull request:

 * Update to supported node versions to latest stable (now v12) and latest LTS (now v10)
 * https://nodejs.org/en/about/releases/
 * https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#specifying-nodejs-versions
 * Also sudo is no longer required: https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

