### PR TITLE
Implement selfAlign{X|Y}, fix flexOrder{Small|Medium|Large}

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,6 @@
-import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { Breakpoints, FloatTypes, HorizontalAlignments, VerticalAlignments, SpaceControls, ExtendedBreakpoints } from './enums';
+import PropTypes from 'prop-types';
+import { Breakpoints, ExtendedBreakpoints, FloatTypes, HorizontalAlignments, SpaceControls, VerticalAlignments } from './enums';
 
 /**
  * Property types for general properties.
@@ -159,7 +159,7 @@ export function setDirection(isVertical, gutters = null) {
 export const FlexboxPropTypes = {
   alignX: PropTypes.oneOf(objectValues(HorizontalAlignments)),
   alignY: PropTypes.oneOf(objectValues(VerticalAlignments)),
-  selfAlignX: PropTypes.oneOf(objectValues(HorizontalAlignments)),
+  selfAlignX: PropTypes.oneOf(objectValues(removeProps(HorizontalAlignments, ['SPACED']))),
   selfAlignY: PropTypes.oneOf(objectValues(VerticalAlignments)),
   centerAlign: PropTypes.bool,
   flexContainer: PropTypes.bool,
@@ -186,14 +186,16 @@ export function flexboxClassNames(props) {
     'align-center-middle': props.centerAlign,
     [`align-${props.alignX}`]: props.alignX,
     [`align-${props.alignY}`]: props.alignY,
+    [`text-${props.selfAlignX}`]: props.selfAlignX,
+    [`align-self-${props.selfAlignY}`]: props.selfAlignY,
     [addBreakpoint('flex-dir-row', props.flexDirRow)]: props.flexDirRow,
     [addBreakpoint('flex-dir-row-reverse', props.flexDirRowRev)]: props.flexDirRowRev,
     [addBreakpoint('flex-dir-column', props.flexDirCol)]: props.flexDirCol,
     [addBreakpoint('flex-dir-column-reverse', props.flexDirColRev)]: props.flexDirColRev,
     [`flex-child-${props.flexChild}`]: props.flexChild,
     [`order-${props.flexOrder}`]: props.flexOrder,
-    [`small-order-${props.flexOrder}`]: props.flexOrderSmall,
-    [`medium-order-${props.flexOrder}`]: props.flexOrderMedium,
-    [`large-order-${props.flexOrder}`]: props.flexOrderLarge
+    [`small-order-${props.flexOrderSmall}`]: props.flexOrderSmall,
+    [`medium-order-${props.flexOrderMedium}`]: props.flexOrderMedium,
+    [`large-order-${props.flexOrderLarge}`]: props.flexOrderLarge
   };
 }

--- a/test/utils-spec.js
+++ b/test/utils-spec.js
@@ -1,9 +1,6 @@
-import React from 'react';
-import { render } from 'enzyme';
 import { expect } from 'chai';
-import { Breakpoints, ExtendedBreakpoints, SpaceControls } from '../src/enums';
-import { removeProps, createClassName, generalClassNames, objectValues, flexboxClassNames } from '../src/utils';
-import {FlexVideo} from '../src/components/flex-video';
+import { Breakpoints, ExtendedBreakpoints, HorizontalAlignments, SpaceControls, VerticalAlignments } from '../src/enums';
+import { createClassName, flexboxClassNames, generalClassNames, objectValues, removeProps } from '../src/utils';
 
 describe('Utilities', () => {
 
@@ -23,10 +20,10 @@ describe('Utilities', () => {
   it('generalClassNames', () => {
     const props = {showFor: Breakpoints.MEDIUM, isHidden: true, showForSr: false, float: 'left'};
     const classNames = generalClassNames(props);
-    expect(classNames['show-for-medium']).to.equal.true;
-    expect(classNames['hide']).to.equal.true;
-    expect(classNames['show-for-sr']).to.equal.false;
-    expect(classNames['float-left']).to.equal.true;
+    expect(classNames['show-for-medium']).to.equal(true);
+    expect(classNames['hide']).to.equal(true);
+    expect(classNames['show-for-sr']).to.equal(false);
+    expect(classNames['float-left']).to.equal(true);
   });
 
   it('objectValues', () => {
@@ -38,11 +35,20 @@ describe('Utilities', () => {
   });
 
   it('flexboxClassNames', () => {
-    const props = {flexDirRow: ExtendedBreakpoints.MEDIUM, flexOrderSmall: 4, flexChild: SpaceControls.GROW};
+    const props = {
+      flexDirRow: ExtendedBreakpoints.MEDIUM,
+      flexOrder: 2,
+      flexOrderSmall: 4,
+      flexChild: SpaceControls.GROW,
+      selfAlignX: HorizontalAlignments.RIGHT,
+      selfAlignY: VerticalAlignments.BOTTOM
+    };
     const classNames = flexboxClassNames(props);
-    expect(classNames['medium-flex-dir-row']).to.equal.true;
-    expect(classNames['small-order-4']).to.equal.true;
-    expect(classNames['flex-child-grow']).to.equal.true;
+    expect(classNames['medium-flex-dir-row']).to.equal('medium');
+    expect(classNames['small-order-4']).to.equal(4);
+    expect(classNames['flex-child-grow']).to.equal('grow');
+    expect(classNames['text-right']).to.equal('right');
+    expect(classNames['align-self-bottom']).to.equal('bottom');
   });
 
 });


### PR DESCRIPTION
Currently, the flexbox props `selfAlignX` and `selfAlignY` are not implemented. This PR implements these props.

- `selfAlignX` does not make sense on flexbox children, see ["There is no justify-self in Flexbox" on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Box_Alignment/Box_Alignment_in_Flexbox#There_is_no_justify-self_in_Flexbox). I see two solutions. This PR implements 1 but I am open to 2 as well.
  1. We center the block contents, not the block itself, by using the [text alignment classes](https://get.foundation/sites/docs/typography-helpers.html#text-alignment).
  2. We remove the `selfAlignX` prop, though is a breaking change because-despite no functional changes-this may result in compilation errors in TypeScript codebases and may require a major version bump (to 1.X).
- `selfAlignY` can easily be implemented using the [`.align-self-*` classes](https://get.foundation/sites/docs/flexbox-utilities.html#vertical-alignment).

Note that in horizontal grids (`.grid-y` aka `<Grid horizontal>`) the X and Y axes are technically swapped but since this is not respected for the `alignX` and `alignY` props, I see no need to respect it for `selfAlignX` and `selfAlignY`.

In addition, this fixes a bug where the `flexOrderSmall`, `flexOrderMedium` and `flexOrderLarge` props  would set the class name based on the `flexOrder` value.

Finally, this fixes the test (which previously did nothing) so it now actually tests the class names.